### PR TITLE
Fixed SessionData's type declaration

### DIFF
--- a/packages/backend/@types/express/index.d.ts
+++ b/packages/backend/@types/express/index.d.ts
@@ -1,0 +1,13 @@
+import { Session, SessionData } from "express-session";
+
+export declare module "express-session" {
+    interface SessionData {
+        userId: string;
+    }
+}
+
+namespace Express {
+    interface Request {
+        session: SessionData;
+    }
+}

--- a/packages/backend/middleware/requireAuth.ts
+++ b/packages/backend/middleware/requireAuth.ts
@@ -1,22 +1,21 @@
 import createError from "http-errors";
-import { RequestHandler } from "express";
+import { Request, Response, RequestHandler, NextFunction } from "express";
 
 const mongoose = require("mongoose");
 
-const requireAuth: RequestHandler = async (req, res, next) => {
-  const user =
-    // @ts-ignore
-    req.session.userId &&
-    // @ts-ignore
-    (await mongoose.model("User").findOne({ _id: req.session.userId }).exec());
+const requireAuth: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
+    const user =
+        req.session.userId &&
 
-  if (!user) {
-    return next(
-      createError(401, "You need to be logged in to perform this action.")
-    );
-  }
+        (await mongoose.model("User").findOne({ _id: req.session.userId }).exec());
 
-  next();
+    if (!user) {
+        return next(
+            createError(401, "You need to be logged in to perform this action.")
+        );
+    }
+
+    next();
 };
 
 export default requireAuth;

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,71 +1,67 @@
 {
-  "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
-    /* Basic Options */
-    // "incremental": true,                         /* Enable incremental compilation */
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
-    // "lib": [],                                   /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                             /* Allow javascript files to be compiled. */
-    // "checkJs": true,                             /* Report errors in .js files. */
-    // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
-    // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                           /* Generates corresponding '.map' file. */
-    // "outFile": "./",                             /* Concatenate and emit output to single file. */
-    // "outDir": "./",                              /* Redirect output structure to the directory. */
-    // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                           /* Enable project compilation */
-    // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
-    // "removeComments": true,                      /* Do not emit comments to output. */
-    // "noEmit": true,                              /* Do not emit outputs. */
-    // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
-    /* Strict Type-Checking Options */
-    "strict": true /* Enable all strict type-checking options. */,
-    // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                    /* Enable strict null checks. */
-    // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Additional Checks */
-    // "noUnusedLocals": true,                      /* Report errors on unused locals. */
-    // "noUnusedParameters": true,                  /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
-    // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
-    // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
-
-    /* Module Resolution Options */
-    // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                             /* List of folders to include type definitions from. */
-    // "types": [],                                 /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
-    // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
-    // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
-
-    /* Advanced Options */
-    "skipLibCheck": true /* Skip type checking of declaration files. */,
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
-  }
+    "compilerOptions": {
+        /* Visit https://aka.ms/tsconfig.json to read more about this file */
+        /* Basic Options */
+        // "incremental": true,                         /* Enable incremental compilation */
+        "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+        "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+        // "lib": [],                                   /* Specify library files to be included in the compilation. */
+        // "allowJs": true,                             /* Allow javascript files to be compiled. */
+        // "checkJs": true,                             /* Report errors in .js files. */
+        // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
+        // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
+        // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
+        // "sourceMap": true,                           /* Generates corresponding '.map' file. */
+        // "outFile": "./",                             /* Concatenate and emit output to single file. */
+        // "outDir": "./",                              /* Redirect output structure to the directory. */
+        // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+        // "composite": true,                           /* Enable project compilation */
+        // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
+        // "removeComments": true,                      /* Do not emit comments to output. */
+        // "noEmit": true,                              /* Do not emit outputs. */
+        // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
+        // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+        // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+        /* Strict Type-Checking Options */
+        "strict": true /* Enable all strict type-checking options. */,
+        // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
+        // "strictNullChecks": true,                    /* Enable strict null checks. */
+        // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
+        // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+        // "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
+        // "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
+        // "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
+        /* Additional Checks */
+        // "noUnusedLocals": true,                      /* Report errors on unused locals. */
+        // "noUnusedParameters": true,                  /* Report errors on unused parameters. */
+        // "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
+        // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
+        // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
+        // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
+        /* Module Resolution Options */
+        // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+        // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
+        // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+        // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
+        "typeRoots": [
+            "@types",
+            "./node_modules/@types",
+        ], /* List of folders to include type definitions from. */
+        // "types": [],                                 /* Type declaration files to be included in compilation. */
+        // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+        "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+        // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
+        // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
+        /* Source Map Options */
+        // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+        // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
+        // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
+        // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+        /* Experimental Options */
+        // "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */
+        // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
+        /* Advanced Options */
+        "skipLibCheck": true /* Skip type checking of declaration files. */,
+        "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+    },
 }

--- a/packages/backend/types.d.ts
+++ b/packages/backend/types.d.ts
@@ -1,20 +1,11 @@
-import { Request } from "express";
-import { Session } from "express-session";
-
 interface Tweet {
-  _id: number;
-  user: User;
-  text: string;
-  createdAt: string;
+    _id: number;
+    user: User;
+    text: string;
+    createdAt: string;
 }
 
 interface User {
-  _id: number;
-  handle: string;
-}
-
-declare module "express-session" {
-  interface SessionData {
-    userId: string;
-  }
+    _id: number;
+    handle: string;
 }


### PR DESCRIPTION
### What

- I created `src/@types/express/index.d.ts` to define our Session object. 
    - For Typescript declaration merging, I matched the file name and its path with the original declaration file and path (i.e., `node_modules/@types` and `src/@types`).

### Why

- The req.sessions.user type needs `//@ts-ignore` in order to work, because the global declaration in `types.d.ts` is not set correctly.