### PR TITLE
FE: Reverted main's file extension to '.js'

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "frontend",
     "version": "1.0.0",
-    "main": "index.ts",
+    "main": "index.js",
     "author": "Monarch Wadia",
     "license": "MIT",
     "scripts": {


### PR DESCRIPTION
### Minor Revision 

- Undid change to "main" in `frontend/package.json` (commit: 2619e5f).
    - entry point, as defined in "main" was returned to **index.js**.*
    - all other `package.json` files are correctly set.

###### *While tackling #14, I redefined the frontend's package/module entry point to **index.ts** (_was index.js_) without realizing its purpose. I think `.ts` is compiled to `.js` along with its type declarations, hence why it's probably best to accept this change.

