### PR TITLE
FE: Optimistically clears input onSubmit (#23)

### DIFF
--- a/packages/frontend/src/components/form/Form.tsx
+++ b/packages/frontend/src/components/form/Form.tsx
@@ -41,6 +41,9 @@ const Form: FunctionComponent<IFormProps> = ({
         // const errors = _validate();
         // setFormErrors(errors);
         onSubmit({errors, values});
+
+        //! TODO - only when if successful, clear input
+        setFormValues(defaultFormStateValues.defaultValues);
     }
 
 


### PR DESCRIPTION
### Summary

#### Bug Fix

- **Problem**: Tweet-Input in `<FeedPage />` does not clear onSubmit.
- **Solution**: Optimistically resets formValues to its defaultValues onSubmit  in Form component.
- **For Consideration:**: Should be improved by incorporating validations and error handling to conditionally reset formValues under the right circumstances.